### PR TITLE
update debian control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Vcs-Git: git://github.com/mxlinux/system-keyboard-qt.git
 
 Package: system-keyboard-qt
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, mx-viewer, flags-common
+Depends: ${misc:Depends}, ${shlibs:Depends}, mx-viewer | antix-viewer, flags-common
 Description: System-keyboard-qt
  A Qt frontend for setxbmap and /etc/default/keyboard


### PR DESCRIPTION
update to debian control file to add and "or" depened of antix-viewer.

important for antix, and for when the help file button is added to the code, we need to make it open either mx-viewer or antix-viewer, which ever is present, or xdg-open help file if neither is present.